### PR TITLE
Upgrades selenium-webdriver to use latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,8 @@ end
 
 group :test, :development do
   gem "rspec-rails"
+  gem 'capybara'
+  gem 'selenium-webdriver'
   gem 'pry'
   gem 'pry-nav'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,13 +50,12 @@ GEM
     atomic (1.1.10)
     bcrypt-ruby (3.1.1)
     builder (3.1.4)
-    capybara (1.1.3)
+    capybara (2.2.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      selenium-webdriver (~> 2.0)
-      xpath (~> 0.1.4)
+      xpath (~> 2.0)
     celluloid (0.12.4)
       facter (>= 1.6.12)
       timers (>= 1.0.0)
@@ -111,7 +110,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.8.7)
       multipart-post (~> 1.1)
-    ffi (1.7.0)
+    ffi (1.9.3)
     fog (1.15.0)
       builder
       excon (~> 0.25.0)
@@ -154,18 +153,20 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     method_source (0.8.1)
-    mime-types (1.23)
+    mime-types (1.25.1)
+    mini_portile (0.5.2)
     minitest (4.7.5)
     modular-scale (1.0.2)
       compass (>= 0.12.1)
       sass (>= 3.2.0)
       sassy-math (>= 1.5)
-    multi_json (1.7.7)
+    multi_json (1.8.2)
     multipart-post (1.2.0)
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (2.6.8)
-    nokogiri (1.5.5)
+    nokogiri (1.6.1)
+      mini_portile (~> 0.5.0)
     orm_adapter (0.4.0)
     pg (0.14.1)
     polyglot (0.3.3)
@@ -219,7 +220,7 @@ GEM
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
     ruby-hmac (0.4.0)
-    rubyzip (0.9.9)
+    rubyzip (1.1.0)
     sass (3.2.12)
     sass-rails (4.0.0)
       railties (>= 4.0.0.beta, < 5.0)
@@ -227,10 +228,10 @@ GEM
       sprockets-rails (~> 2.0.0)
     sassy-math (1.5)
       compass (~> 0.11)
-    selenium-webdriver (2.32.1)
+    selenium-webdriver (2.38.0)
       childprocess (>= 0.2.5)
       multi_json (~> 1.0)
-      rubyzip
+      rubyzip (~> 1.0)
       websocket (~> 1.0.4)
     shoulda-matchers (1.4.1)
       activesupport (>= 3.0.0)
@@ -280,7 +281,7 @@ GEM
     warden (1.2.3)
       rack (>= 1.0)
     websocket (1.0.7)
-    xpath (0.1.4)
+    xpath (2.0.0)
       nokogiri (~> 1.3)
     zurb-foundation (3.0.9)
       compass (>= 0.12.2)
@@ -294,6 +295,7 @@ PLATFORMS
 DEPENDENCIES
   addressable
   asset_sync
+  capybara
   coffee-rails (~> 4.0.0)
   compass-rails
   contenteditable!
@@ -322,6 +324,7 @@ DEPENDENCIES
   redcarpet (~> 1.17.2)
   rspec-rails
   sass-rails (~> 4.0.0)
+  selenium-webdriver
   shoulda-matchers
   sidekiq
   simplecov

--- a/app/views/attendances/_rsvp.html.haml
+++ b/app/views/attendances/_rsvp.html.haml
@@ -12,7 +12,7 @@
           %a.a_button{:href => "/rsvp/#{lesson.id}", 'data-remote' => true, 'data-method' => 'POST'}
             RSVP!
       -else
-        %a.a_button{:href => "/rsvp/#{lesson.id}", 'data-reveal-id' => 'LoginModal', 'data-remote' => true}
+        %a.a_button{:href => "/rsvp/#{lesson.id}", 'data-reveal-id' => 'LoginModal', 'data-remote' => true, 'data-method' => 'POST'}
           RSVP!
     .text
       #{pluralize(lesson.users.count, "student")}

--- a/spec/acceptance/login_spec.rb
+++ b/spec/acceptance/login_spec.rb
@@ -11,6 +11,7 @@ feature %q{
     @user = FactoryGirl.create(:user)
     visit root_path
     click_link "Login"
+    page.should have_field "user[email]"
     fill_in "user[email]", :with => @user.email
     fill_in "user[password]", :with => "draft1"
     click_button "Sign in"

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,8 +1,10 @@
 module Helpers
   def sign_in_manually(user)
     visit new_user_session_path
-    fill_in "user[email]", :with => user.email
-    fill_in "user[password]", :with => "draft1"
-    click_button "Sign in"
+    within first(:css, '#new_user') do
+      fill_in "user[email]", :with => user.email
+      fill_in "user[password]", :with => "draft1"
+      click_button "Sign in"
+    end
   end
 end


### PR DESCRIPTION
- fixes an issue with latest firefox on osx, where first test would fail due to an erroneous timeout
- capybara 2 is more finnicky when it comes to ambiguous matches (it doesn't allow for them)
- fixed a remote link to use POST for a test that should have been failing with previous capybara, since there's no route for `GET /rsvp`
