### PR TITLE
improves potentially offensive language

### DIFF
--- a/app/views/polls/_poll.html.haml
+++ b/app/views/polls/_poll.html.haml
@@ -31,7 +31,7 @@
     %h2 Polls
     Please
     %a{:href => "#", "data-reveal-id" => "LoginModal"} sign in
-    , baby!
+
 
 
 


### PR DESCRIPTION
We've been having a difficult time retaining female programmers in our cville school, so I reached out to a woman who had attended a few classes but no longer comes for feedback. From her response:

> I think it would be nice to sprinkle some RailsSchool 101 sessions throughout to cover what RailsSchool is, helping folks get their laptop setup and some basic intro to coding. Finally, invitation is key - from personal invites to the language used on the site & in descriptions. For instance, there's this under Polls on the railsschool website - "Please sign in , baby!"

This pull request addresses that last point, since it's a really simple fix.
