### PR TITLE
Fixes inconsistent timezone in emails and lesson time edit, fixes #34

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 require_dependency "user_sanitizer"
 
 class ApplicationController < ActionController::Base
-  before_filter :set_time_zone
+  around_filter :set_time_zone
 
   protect_from_forgery
   helper_method :current_school
@@ -46,8 +46,8 @@ class ApplicationController < ActionController::Base
     @current_school
   end
 
-  def set_time_zone
-    Time.zone = current_school.timezone
+  def set_time_zone(&block)
+    Time.use_zone(current_school.timezone, &block)
   end
 
   def devise_parameter_sanitizer

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,4 +1,5 @@
 class LessonsController < ApplicationController
+  around_filter :school_timezone, only: [:create, :update]
   before_filter :fix_dates, only: [:create, :update]
   before_filter :convert_slug_to_id
   load_and_authorize_resource except: [:index]
@@ -104,10 +105,16 @@ private
     end
   end
 
+  def school_timezone(&block)
+    l_params = params[:lesson]
+    if l_params
+      Time.use_zone(Venue.find(l_params[:venue_id]).school.timezone, &block)
+    end
+  end
+
   def fix_dates
     l_params = params[:lesson]
     if l_params
-      Time.zone = Venue.find(l_params[:venue_id]).school.timezone
       date = l_params.delete("date")
       l_params[:start_time] =
         Time.zone.parse("#{date} #{l_params[:start_time]}")

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -4,16 +4,17 @@ class NotificationMailer < ActionMailer::Base
 
   def lesson_notification(lesson_id, to_id, from_id)
     @lesson = Lesson.find(lesson_id)
-    @user = User.find(to_id)
-    from_user = User.find(from_id)
     # Takes timezone into account
-    Time.zone = @lesson.venue.school.timezone
-    @lesson.reload
-    subject = "Rails class #{@lesson.start_time.strftime("%-m/%-d")}: #{@lesson.title}"
-    calendar = @lesson.to_ics
-    attachments['calendar.ics'] = calendar
-    mail(to: format_email_field(@user), subject: subject,
-         from: format_email_field(from_user))
+    Time.use_zone(@lesson.venue.school.timezone) do
+      @user = User.find(to_id)
+      from_user = User.find(from_id)
+      @lesson.reload
+      subject = "Rails class #{@lesson.start_time.strftime("%-m/%-d")}: #{@lesson.title}"
+      calendar = @lesson.to_ics
+      attachments['calendar.ics'] = calendar
+      mail(to: format_email_field(@user), subject: subject,
+           from: format_email_field(from_user))
+    end
   end
 
   def send_lesson_message(lesson_id, subject, message, user_id)

--- a/app/views/lessons/_form.html.haml
+++ b/app/views/lessons/_form.html.haml
@@ -3,9 +3,9 @@
 
   - # Get the time in the right timezone for an existing lesson
   - if(@lesson.venue)
-    - Time.zone = @lesson.venue.school.timezone
-    - @lesson.start_time = Time.zone.parse(@lesson.start_time.to_s)
-    - @lesson.end_time = Time.zone.parse(@lesson.end_time.to_s)
+    - Time.use_zone(@lesson.venue.school.timezone) do
+      - @lesson.start_time = Time.zone.parse(@lesson.start_time.to_s)
+      - @lesson.end_time = Time.zone.parse(@lesson.end_time.to_s)
 
   .field
     = f.label :title
@@ -20,7 +20,7 @@
     =f.label :date
     -# TODO replace this with date helper when upgrading to Rails 4
     %input{id: "lesson_date", name: "lesson[date]", type: "date",
-           value: @lesson.start_time ? @lesson.start_time : Date.current}
+           value: @lesson.start_time ? @lesson.start_time.to_date : Date.current}
   .field
     =f.label :start_time
     -# TODO replace this with time helper when upgrading to Rails 4

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,3 +36,6 @@ Rs::Application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 end
+
+# Let's set a different timezone to test timezones handling
+Time.zone = "Paris"

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -9,7 +9,7 @@ describe UsersController do
       ApplicationController.any_instance.stub(:current_school).and_return(
         # Let's create an anonymous object responding to 
         # methods timezone and slug 
-        # so the before_filter set_time_zone works always
+        # so the around_filter set_time_zone works always
         OpenStruct.new(
           timezone: "Pacific Time (US & Canada)", 
           slug: "pretty-cool-completely-virtual-lesson"


### PR DESCRIPTION
Some best practices may fix that famous issue #34, I hope. All the tests are working and apart from the different Time.zone in config/environment/test.rb, I really don't see how to make the tests better, I ensured myself that the tests cover sending notification mails with two different school timezones and it does!
I hope it'll work, else I really don't understand what's happening for now; we'll unfortunately really see if it works with the next real notification mail sent.
