### PR TITLE
prevents slugs like 27-aug-sth from linking to id=27

### DIFF
--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -98,10 +98,14 @@ class LessonsController < ApplicationController
 
 private
   def convert_slug_to_id
-    if (params[:id] && !(params[:id].to_i > 0))
+    if id_is_slug?(params[:id])
       l = Lesson.find_by_slug(params[:id])
       params[:id] = l.id if l.present?
     end
+  end
+
+  def id_is_slug?(id)
+    id && !(id.to_i > 0 && id.to_i.to_s == id)
   end
 
   def fix_dates


### PR DESCRIPTION
http://www.railsschool.org/l/27-aug-2014-beginner was linking to a course from 2012 about devise with id=27 because `27-aug-2014-beginner.to_i == 27`
