### PR TITLE
update badges to only give them to confirmed attendances

### DIFF
--- a/app/models/badges/boba_fett.rb
+++ b/app/models/badges/boba_fett.rb
@@ -14,6 +14,6 @@ class Badge::BobaFett
   end
 
   def self.allocate_to_user?(user)
-    user.attendances.count >= 35
+    user.attendances.where(confirmed: true).count >= 35
   end
 end

--- a/app/models/badges/ewok.rb
+++ b/app/models/badges/ewok.rb
@@ -14,6 +14,6 @@ class Badge::Ewok
   end
 
   def self.allocate_to_user?(user)
-    user.attendances.count >= 5
+    user.attendances.where(confirmed: true).count >= 5
   end
 end

--- a/app/models/badges/greedo.rb
+++ b/app/models/badges/greedo.rb
@@ -14,6 +14,6 @@ class Badge::Greedo
   end
 
   def self.allocate_to_user?(user)
-    user.attendances.count >= 15
+    user.attendances.where(confirmed: true).count >= 15
   end
 end

--- a/app/models/badges/han_solo.rb
+++ b/app/models/badges/han_solo.rb
@@ -14,6 +14,6 @@ class Badge::HanSolo
   end
 
   def self.allocate_to_user?(user)
-    user.attendances.count >= 100
+    user.attendances.where(confirmed: true).count >= 100
   end
 end

--- a/app/models/badges/jabba.rb
+++ b/app/models/badges/jabba.rb
@@ -14,6 +14,6 @@ class Badge::Jabba
   end
 
   def self.allocate_to_user?(user)
-    user.attendances.count >= 50
+    user.attendances.where(confirmed: true).count >= 50
   end
 end

--- a/app/models/badges/jar_jar_binks.rb
+++ b/app/models/badges/jar_jar_binks.rb
@@ -14,6 +14,6 @@ class Badge::JarJarBinks
   end
 
   def self.allocate_to_user?(user)
-    user.attendances.count >= 1
+    user.attendances.where(confirmed: true).count >= 1
   end
 end

--- a/spec/models/badges/boba_fett_spec.rb
+++ b/spec/models/badges/boba_fett_spec.rb
@@ -10,18 +10,23 @@ describe Badge::BobaFett do
       it { should eq(false) }
     end
 
+    context "user rsvp'd but did not attend classes" do
+      before { 35.times { create(:attendance, confirmed: false, user: user) } }
+      it { should eq(false) }
+    end
+
     context "user attended less than 35 classes" do
-      before { 34.times { create(:attendance, user: user) } }
+      before { 34.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(false) }
     end
 
     context "user attended exactly 35 classes" do
-      before { 35.times { create(:attendance, user: user) } }
+      before { 35.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(true) }
     end
 
     context "user attended more than 35" do
-      before { 36.times { create(:attendance, user: user) } }
+      before { 36.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(true) }
     end
   end

--- a/spec/models/badges/ewok_spec.rb
+++ b/spec/models/badges/ewok_spec.rb
@@ -11,18 +11,23 @@ describe Badge::Ewok do
       it { should eq(false) }
     end
 
+    context "user rsvp'd but did not attend classes" do
+      before { 5.times { create(:attendance, confirmed: false, user: user) } }
+      it { should eq(false) }
+    end
+
     context "user attended less than 5 classes" do
-      before { 4.times { create(:attendance, user: user) } }
+      before { 4.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(false) }
     end
 
     context "user attended exactly 5 classes" do
-      before { 5.times { create(:attendance, user: user) } }
+      before { 5.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(true) }
     end
 
     context "user attended more than 5 classes" do
-      before { 6.times { create(:attendance, user: user) } }
+      before { 6.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(true) }
     end
   end

--- a/spec/models/badges/greedo_spec.rb
+++ b/spec/models/badges/greedo_spec.rb
@@ -10,18 +10,24 @@ describe Badge::Greedo do
       it { should eq(false) }
     end
 
+    context "user rsvp'd but did not attend classes" do
+      before { 15.times { create(:attendance, confirmed: false, user: user) } }
+      it { should eq(false) }
+    end
+
+
     context "user attended less than 15 classes" do
-      before { 14.times { create(:attendance, user: user) } }
+      before { 14.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(false) }
     end
 
     context "user attended exactly 15 classes" do
-      before { 15.times { create(:attendance, user: user) } }
+      before { 15.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(true) }
     end
 
     context "user attended more than 15 classes" do
-      before { 16.times { create(:attendance, user: user) } }
+      before { 16.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(true) }
     end
   end

--- a/spec/models/badges/greedo_spec.rb
+++ b/spec/models/badges/greedo_spec.rb
@@ -15,7 +15,6 @@ describe Badge::Greedo do
       it { should eq(false) }
     end
 
-
     context "user attended less than 15 classes" do
       before { 14.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(false) }

--- a/spec/models/badges/han_solo_spec.rb
+++ b/spec/models/badges/han_solo_spec.rb
@@ -10,18 +10,23 @@ describe Badge::HanSolo do
       it { should eq(false) }
     end
 
+    context "user rsvp'd but did not attend classes" do
+      before { 100.times { create(:attendance, confirmed: false, user: user) } }
+      it { should eq(false) }
+    end
+
     context "user attended less than 100 classes" do
-      before { 99.times { create(:attendance, user: user) } }
+      before { 99.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(false) }
     end
 
     context "user attended exactly 100 classes" do
-      before { 100.times { create(:attendance, user: user) } }
+      before { 100.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(true) }
     end
 
     context "user attended more than 100 classes" do
-      before { 101.times { create(:attendance, user: user) } }
+      before { 101.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(true) }
     end
   end

--- a/spec/models/badges/jabba_spec.rb
+++ b/spec/models/badges/jabba_spec.rb
@@ -10,18 +10,23 @@ describe Badge::Jabba do
       it { should eq(false) }
     end
 
+    context "user rsvp'd but did not attend classes" do
+      before { 50.times { create(:attendance, confirmed: false, user: user) } }
+      it { should eq(false) }
+    end
+
     context "user attended less than 50 classes" do
-      before { 49.times { create(:attendance, user: user) } }
+      before { 49.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(false) }
     end
 
     context "user attended exactly 50 classes" do
-      before { 50.times { create(:attendance, user: user) } }
+      before { 50.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(true) }
     end
 
     context "user attended more than 50 classes" do
-      before { 51.times { create(:attendance, user: user) } }
+      before { 51.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(true) }
     end
   end

--- a/spec/models/badges/jar_jar_binks_spec.rb
+++ b/spec/models/badges/jar_jar_binks_spec.rb
@@ -10,13 +10,18 @@ describe Badge::JarJarBinks do
       it { should eq(false) }
     end
 
+    context "user rsvp'd but did not attend a class" do
+      before { create(:attendance, confirmed: false, user: user) }
+      it { should eq(false) }
+    end
+
     context "user attended one class" do
-      before { create(:attendance, user: user) }
+      before { create(:attendance, confirmed: true, user: user) }
       it { should eq(true) }
     end
 
     context "user attended more than one class" do
-      before { 2.times { create(:attendance, user: user) } }
+      before { 2.times { create(:attendance, confirmed: true, user: user) } }
       it { should eq(true) }
     end
   end


### PR DESCRIPTION
Updates the new badges to only give them to users who actually attended a class. Also added spec examples to cover unconfirmed attendances. 

The new specs run a bit slow as I'm making a ton of db records, seems OK for now. 