### PR TITLE
update sendgrid webhook route to get

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rs::Application.routes.draw do
 
   # handle SendGrid bounces. For some reason they're sending this as get
   get "bounce_reports" => "users#report_email_bounce"
+  post "bounce_reports" => "users#report_email_bounce"
 
   root :to => 'home#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,9 @@ Rs::Application.routes.draw do
   post "notify_subscribers/:id" => "users#notify_subscribers", :as => "notify_subscribers"
   post "rsvp/:id" => "attendances#rsvp"
   post "rsvp/:id/:delete" => "attendances#rsvp"
-  post "bounce_reports" => "users#report_email_bounce"
+
+  # handle SendGrid bounces. For some reason they're sending this as get
+  get "bounce_reports" => "users#report_email_bounce"
 
   root :to => 'home#index'
 


### PR DESCRIPTION
Even though SendGrid says they are posting, the logs say the request is a GET. So update the route. 