### PR TITLE
add a worker to fix spam flags from sendgrid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :test do
   gem 'simplecov', :require => false # code coverage tool
   gem "database_cleaner"
   gem 'email_spec'
+  gem "webmock"
 end
 
 group :test, :development do

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "unicorn"
 gem "rack-timeout", '0.0.4' # https://github.com/heroku/rack-timeout/issues/55
 gem "sidekiq"
 gem "sinatra", require: false # Required for Sidekiq web interface
-
+gem 'whenever', :require => false
 gem "devise-async"
 gem "gravatar-ultimate"
 # render markdown

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
     compass-rails (2.0.0)
       compass (>= 0.12.2)
     connection_pool (1.2.0)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     database_cleaner (1.2.0)
     devise (3.4.1)
       bcrypt (~> 3.0)
@@ -234,6 +236,7 @@ GEM
     rspec-support (3.2.1)
     ruby_parser (3.6.4)
       sexp_processor (~> 4.1)
+    safe_yaml (1.0.4)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
@@ -299,6 +302,9 @@ GEM
       raindrops (~> 0.7)
     warden (1.2.3)
       rack (>= 1.0)
+    webmock (1.20.4)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
     websocket-driver (0.5.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.1)
@@ -355,4 +361,5 @@ DEPENDENCIES
   twitter
   uglifier (~> 2.1.1)
   unicorn
+  webmock
   zurb-foundation (= 3.0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,6 +308,8 @@ GEM
     websocket-driver (0.5.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.1)
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     zurb-foundation (3.0.9)
@@ -362,4 +364,5 @@ DEPENDENCIES
   uglifier (~> 2.1.1)
   unicorn
   webmock
+  whenever
   zurb-foundation (= 3.0.9)

--- a/app/workers/spam_catcher.rb
+++ b/app/workers/spam_catcher.rb
@@ -1,0 +1,33 @@
+class SpamCatcher
+  include Sidekiq::Worker
+  # This job is to check any emails in Sendgrid that are flagged as spam.
+  SENDGRID_USERNAME = ENV["SENDGRID_USERNAME"]
+  SENDGRID_PASSWORD = ENV["SENDGRID_PASSWORD"]
+  POST_URL = "https://api.sendgrid.com/api/spamreports.delete.json"
+  GET_URL = "https://api.sendgrid.com/api/spamreports.get.json?" \
+            "api_user=#{SENDGRID_USERNAME}&" \
+            "api_key=#{SENDGRID_PASSWORD}&date=1"
+
+  def perform
+    process_spam_reports
+  end
+
+  private
+
+  def process_spam_reports
+    response = HTTParty.get(GET_URL)
+    if response.code == 200
+      spam_reports = JSON.parse(response.parsed_response)
+      spam_reports.each { |report| delete_spam_report(report["email"]) }
+    end
+  end
+
+  def delete_spam_report(email)
+    post_params = { api_user: SENDGRID_USERNAME,
+                    api_key: SENDGRID_PASSWORD }
+    result = HTTParty.post(POST_URL,
+                           query: post_params.merge!( email: email ) )
+    logger.info("Got spam report for #{email}. " \
+                "SendGrid says #{result.parsed_response}")
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,3 @@
+every 1.day, at: "8:00 am" do
+  runner "SpamCatcher.perform_async"
+end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,5 +1,0 @@
-desc "Heroku scheduler file"
-
-task clean_spam: :environment do
-  SpamCatcher.perform_async
-end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,5 @@
+desc "Heroku scheduler file"
+
+task clean_spam: :environment do
+  SpamCatcher.perform_async
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,10 @@ require "email_spec"
 require 'capybara/poltergeist'
 require_relative 'helpers'
 require 'sidekiq/testing'
+require "support/fake_send_grid"
 Sidekiq::Testing.inline!
+WebMock.allow_net_connect! # only stubbing SendGrid for now
+WebMock.stub_request(:any, /api.sendgrid.com/).to_rack(FakeSendGrid)
 
 ActiveRecord::Migration.maintain_test_schema!
 
@@ -30,7 +33,6 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :controller
   config.infer_spec_type_from_file_location!
 
-  # enable both should and expect syntax
   config.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
 end
 

--- a/spec/support/fake_send_grid.rb
+++ b/spec/support/fake_send_grid.rb
@@ -1,0 +1,17 @@
+require "sinatra/base"
+
+class FakeSendGrid < Sinatra::Base
+  get "/api/spamreports.get.json?" do
+    content_type :text
+    response = '[{"ip": "174.36.80.219","email": "example@aol.com",' \
+               '"created": "2009-12-06 15:45:08"},{"ip": "74.63.202.105",' \
+               '"email": "example2@yahoo.com",' \
+               '"created": "2009-12-08 07:43:01"}]'
+    response
+  end
+
+  post "/api/spamreports.delete.json" do
+    content_type :json
+    '{ "message": "success" }'
+  end
+end

--- a/spec/workers/spam_catcher_spec.rb
+++ b/spec/workers/spam_catcher_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+describe SpamCatcher do
+  describe ".perform_async" do
+    context "fixing a spam report" do
+      let(:result) { SpamCatcher.perform_async }
+      it "should return true" do
+        expect(result).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a worker to check for spam requests at SendGrid and then remove them. This is necessary because we often get marked as spam when we send to the NoiseBridge list. 

Also ads a basic sanity test and a Sinatra fake SendGrid, for stubbing. 