### PR TITLE
Spam webhook

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -54,12 +54,7 @@ class UsersController < ApplicationController
 
   # POST /bounce_reports
   def report_email_bounce
-    params[:_json].each do |payload|
-      if payload[:email].present? && payload[:event] == "bounce"
-        user = User.find_by_email(payload[:email])
-        user.update_attributes(subscribe_lesson_notifications: false) if user
-      end
-    end
+    SendgridEventService.new(request_params: params).perform
     head status: 200 # sendgrid demands a 200
   end
 

--- a/app/services/sendgrid_event_service.rb
+++ b/app/services/sendgrid_event_service.rb
@@ -13,7 +13,7 @@ class SendgridEventService
       if event[:email].present? && HANDLED_EVENTS.include?(event[:event])
         user = User.find_by(email: event[:email])
         method_name = "process_#{event[:event]}_event".to_sym
-        self.send(method_name, user) if user
+        send(method_name, user) if user
       end
     end
   end

--- a/app/services/sendgrid_event_service.rb
+++ b/app/services/sendgrid_event_service.rb
@@ -1,0 +1,48 @@
+class SendgridEventService
+  # Service Object to process event webhooks from SendGrid. Events not listed
+  # in HANDLED_EVENTS will be ignored.
+  HANDLED_EVENTS = %w[bounce spamreport]
+  POST_URL = "https://api.sendgrid.com/api/spamreports.delete.json"
+
+  def initialize(request_params: {})
+    @request_params = request_params
+  end
+
+  def perform
+    @request_params[:_json].each do |event|
+      if event[:email].present? && HANDLED_EVENTS.include?(event[:event])
+        user = User.find_by(email: event[:email])
+        method_name = "process_#{event[:event]}_event".to_sym
+        self.send(method_name, user) if user
+      end
+    end
+  end
+
+  private
+
+  def process_bounce_event(user)
+    unsubscribe_user(user)
+  end
+
+  def process_spamreport_event(user)
+    # if the user does not have an unsubscribe token, then the user is actually
+    # an email list. In this case we do not want to unsubscribe the user,
+    # instead we want to delete the spam report at sendgrid
+    if user.unsubscribe_token.present?
+      unsubscribe_user(user)
+    else
+      delete_spam_report(user)
+    end
+  end
+
+  def unsubscribe_user(user)
+    user.update_attributes(subscribe_lesson_notifications: false,
+                           subscribe_badge_notifications: false)
+  end
+
+  def delete_spam_report(user)
+    post_params = { api_user: ENV["SENDGRID_USERNAME"],
+                    api_key: ENV["SENDGRID_PASSWORD"] }
+    HTTParty.post(POST_URL, query: post_params.merge!(email: user.email))
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,7 @@ module Rs
 
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += %W(#{config.root}/lib)
+    config.autoload_paths += %W(#{config.root}/app/services)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -3,12 +3,13 @@ require 'factory_girl'
 FactoryGirl.define do
 
   factory :user do |u|
-    u.name                   "Test User that loves beer"
-    sequence(:email) { |i| "user_#{i}@example.com"}
-    u.password               "draft1"
-    u.password_confirmation  "draft1"
-    u.subscribe_lesson_notifications   true
-    u.admin                   false
+    u.name                            "Test User that loves beer"
+    sequence(:email)                  { |i| "user_#{i}@example.com"}
+    u.password                        "draft1"
+    u.password_confirmation           "draft1"
+    u.subscribe_lesson_notifications  true
+    u.subscribe_badge_notifications   true
+    u.admin                           false
     school
   end
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
 
   factory :user do |u|
     u.name                            "Test User that loves beer"
-    sequence(:email)                  { |i| "user_#{i}@example.com"}
+    sequence(:email)                  { |i| "user_#{i}@example.com" }
     u.password                        "draft1"
     u.password_confirmation           "draft1"
     u.subscribe_lesson_notifications  true

--- a/spec/fixtures/sendgrid_webhook.json
+++ b/spec/fixtures/sendgrid_webhook.json
@@ -1,0 +1,37 @@
+{ "_json":
+  [
+    {
+        "uid": "123456",
+        "status": "5.1.1",
+        "sg_event_id": "X_C_clhwSIi4EStEpol-SQ",
+        "reason": "550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces. Learn more at http: //support.google.com/mail/bin/answer.py?answer=6596 do3si8775385pbc.262 - gsmtp ",
+        "purchase": "PO1452297845",
+        "event": "bounce",
+        "email": "bouncedemail@example.com",
+        "timestamp": 1386637483,
+        "smtp-id": "<142da08cd6e.5e4a.310b89@localhost.localdomain>",
+        "type": "bounce",
+        "category": ["category1","category2","category3"],
+        "id": "001"
+    },
+    {
+        "email":"spamemail@example.com",
+        "timestamp":1386638248,
+        "uid":"123456",
+        "purchase":"PO1452297845",
+        "id":"001",
+        "category":["category1","category2","category3"],
+        "event":"spamreport"
+    },
+    {
+        "email":"listemail@example.com",
+        "timestamp":1386638248,
+        "uid":"123456",
+        "purchase":"PO1452297845",
+        "id":"001",
+        "category":["category1","category2","category3"],
+        "event":"spamreport"
+    }
+
+  ]
+}

--- a/spec/services/sendgrid_event_service_spec.rb
+++ b/spec/services/sendgrid_event_service_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe SendgridEventService do
+  file_path = "spec/fixtures/sendgrid_webhook.json"
+  webhook_payload = JSON.parse(File.open(file_path, "rb")
+                               .read).with_indifferent_access
+
+  context "when an email bounces" do
+    let!(:bounced_user) { create(:user, email: "bouncedemail@example.com") }
+    before { SendgridEventService.new(request_params: webhook_payload).perform }
+
+    it "should unsubscribe the user" do
+      expect(bounced_user.reload.subscribe_lesson_notifications).to be_falsey
+      expect(bounced_user.subscribe_badge_notifications).to be_falsey
+    end
+  end
+
+  context "when a user marks our email as spam" do
+    let!(:spam_user) { create(:user, email: "spamemail@example.com") }
+    before { SendgridEventService.new(request_params: webhook_payload).perform }
+
+    it "should unsubscribe the user" do
+      expect(spam_user.reload.subscribe_lesson_notifications).to be_falsey
+      expect(spam_user.subscribe_badge_notifications).to be_falsey
+    end
+  end
+
+  context "when one of our mailing list emails is marked as spam" do
+    let!(:list_user) { create(:user, email: "listemail@example.com",
+                                     password: nil,
+                                     password_confirmation: nil) }
+    before do
+      SendgridEventService.new(request_params: webhook_payload).perform
+    end
+
+    it "should not unsubscribe the user" do
+      expect(list_user.reload.subscribe_lesson_notifications).to be_truthy
+      expect(list_user.subscribe_badge_notifications).to be_truthy
+    end
+  end
+end

--- a/spec/services/sendgrid_event_service_spec.rb
+++ b/spec/services/sendgrid_event_service_spec.rb
@@ -1,9 +1,11 @@
 require "spec_helper"
 
 describe SendgridEventService do
-  file_path = "spec/fixtures/sendgrid_webhook.json"
-  webhook_payload = JSON.parse(File.open(file_path, "rb")
-                               .read).with_indifferent_access
+  let(:webhook_payload) do
+    JSON.parse(
+      File.open("spec/fixtures/sendgrid_webhook.json", "rb").read
+    ).with_indifferent_access
+  end
 
   context "when an email bounces" do
     let!(:bounced_user) { create(:user, email: "bouncedemail@example.com") }
@@ -26,9 +28,12 @@ describe SendgridEventService do
   end
 
   context "when one of our mailing list emails is marked as spam" do
-    let!(:list_user) { create(:user, email: "listemail@example.com",
-                                     password: nil,
-                                     password_confirmation: nil) }
+    let!(:list_user) {
+      create(:user, email: "listemail@example.com",
+                    password: nil,
+                    password_confirmation: nil)
+    }
+
     before do
       SendgridEventService.new(request_params: webhook_payload).perform
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,9 +9,11 @@ require 'capybara/poltergeist'
 require_relative 'helpers'
 require 'sidekiq/testing'
 require "support/fake_code_wars"
+require "support/fake_send_grid"
 Sidekiq::Testing.inline!
 WebMock.allow_net_connect! # only stubbing CodeWars for now
 WebMock.stub_request(:any, /codewars.com/).to_rack(FakeCodeWars)
+WebMock.stub_request(:any, /api.sendgrid.com/).to_rack(FakeSendGrid)
 
 ActiveRecord::Migration.maintain_test_schema!
 

--- a/spec/support/fake_send_grid.rb
+++ b/spec/support/fake_send_grid.rb
@@ -1,0 +1,8 @@
+require "sinatra/base"
+
+class FakeSendGrid < Sinatra::Base
+  post "/api/spamreports.delete.json" do
+    content_type :json
+    '{ "message": "success" }'
+  end
+end


### PR DESCRIPTION
Fixes issues 138 and 139 by adding a service object to deal with both spam reports and bounce events from SendGrid, via webhooks