### PR TITLE
Use hangout url for blank archive url

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -13,7 +13,7 @@ class Lesson < ActiveRecord::Base
   end
 
   def set_blank_archive_url
-    archivable_hangout_url = /\Ahttps?:\/\/plus.google/i
+    archivable_hangout_url = /\Ahttps?:\/\/plus\.google\.com\/(?!.*hoaevent.*)(?=events\/.+)/i
     if archive_url.blank? && hangout_url.try(:match, archivable_hangout_url)
       self.archive_url = hangout_url
     end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -13,7 +13,7 @@ class Lesson < ActiveRecord::Base
   end
 
   def set_blank_archive_url
-    archivable_hangout_url = 
+    archivable_hangout_url =
       /\Ahttps?:\/\/plus\.google\.com\/(?!.*hoaevent.*)(?=events\/.+)/i
     if archive_url.blank? && hangout_url.try(:match, archivable_hangout_url)
       self.archive_url = hangout_url

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -13,7 +13,8 @@ class Lesson < ActiveRecord::Base
   end
 
   def set_blank_archive_url
-    archivable_hangout_url = /\Ahttps?:\/\/plus\.google\.com\/(?!.*hoaevent.*)(?=events\/.+)/i
+    archivable_hangout_url = 
+      /\Ahttps?:\/\/plus\.google\.com\/(?!.*hoaevent.*)(?=events\/.+)/i
     if archive_url.blank? && hangout_url.try(:match, archivable_hangout_url)
       self.archive_url = hangout_url
     end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -4,11 +4,19 @@ class Lesson < ActiveRecord::Base
   has_many :attendances
   has_many :users, :through => :attendances
   before_save :generate_slug
+  before_save :set_blank_archive_url
   belongs_to :venue
   belongs_to :teacher, class_name: "User"
 
   def generate_slug
     self.slug = Slug.new(title).generate if self.slug.blank?
+  end
+
+  def set_blank_archive_url
+    archivable_hangout_url = /\Ahttps?:\/\/plus.google/i
+    if archive_url.blank? && hangout_url.try(:match, archivable_hangout_url)
+      self.archive_url = hangout_url
+    end
   end
 
   def to_param

--- a/spec/acceptance/lessons_spec.rb
+++ b/spec/acceptance/lessons_spec.rb
@@ -110,7 +110,8 @@ end
 feature %q{
   As a website
   I want to make sure,
-  That when a lesson with a google plus events hangout url but no archive url is saved
+  That when a lesson with a google plus events hangout url but no 
+    archive url is saved
   The archive url is set to the google plus events hangout url
 } do
 

--- a/spec/acceptance/lessons_spec.rb
+++ b/spec/acceptance/lessons_spec.rb
@@ -110,11 +110,10 @@ end
 feature %q{
   As a website
   I want to make sure,
-  That when a lesson with a google plus events hangout url but no 
+  That when a lesson with a google plus events hangout url but no
     archive url is saved
   The archive url is set to the google plus events hangout url
 } do
-
   background do
     @lesson = FactoryGirl.build(:lesson)
   end

--- a/spec/acceptance/lessons_spec.rb
+++ b/spec/acceptance/lessons_spec.rb
@@ -110,21 +110,30 @@ end
 feature %q{
   As a website
   I want to make sure,
-  That when a lesson with a google plus hangout url but no archive url is saved
-  The archive url is set to the google plus hangout url
+  That when a lesson with a google plus events hangout url but no archive url is saved
+  The archive url is set to the google plus events hangout url
 } do
 
   background do
     @lesson = FactoryGirl.build(:lesson)
   end
 
-  scenario "creating a lesson with a google plus url", js: true do
+  scenario "creating a lesson with a google plus events url", js: true do
     @lesson.hangout_url = "https://plus.google.com/events/foo"
     @lesson.archive_url.should == nil
     @lesson.save!
     lessons = Lesson.all
     lessons.count.should == 1
     lessons.first.archive_url.should == "https://plus.google.com/events/foo"
+  end
+
+  scenario "creating a lesson with a google plus hoaevent url", js: true do
+    @lesson.hangout_url = "https://plus.google.com/hangouts/_/hoaevent/foo"
+    @lesson.archive_url.should == nil
+    @lesson.save!
+    lessons = Lesson.all
+    lessons.count.should == 1
+    lessons.first.archive_url.should == nil
   end
 
   scenario "creating a lesson with a non-google plus url", js: true do

--- a/spec/acceptance/lessons_spec.rb
+++ b/spec/acceptance/lessons_spec.rb
@@ -110,6 +110,36 @@ end
 feature %q{
   As a website
   I want to make sure,
+  That when a lesson with a google plus hangout url but no archive url is saved
+  The archive url is set to the google plus hangout url
+} do
+
+  background do
+    @lesson = FactoryGirl.build(:lesson)
+  end
+
+  scenario "creating a lesson with a google plus url", js: true do
+    @lesson.hangout_url = "https://plus.google.com/events/foo"
+    @lesson.archive_url.should == nil
+    @lesson.save!
+    lessons = Lesson.all
+    lessons.count.should == 1
+    lessons.first.archive_url.should == "https://plus.google.com/events/foo"
+  end
+
+  scenario "creating a lesson with a non-google plus url", js: true do
+    @lesson.hangout_url = "https://talkgadget.com/events/foo"
+    @lesson.archive_url.should == nil
+    @lesson.save!
+    lessons = Lesson.all
+    lessons.count.should == 1
+    lessons.first.archive_url.should == nil
+  end
+end
+
+feature %q{
+  As a website
+  I want to make sure,
   That the admin can create lessons
   So the admin can create lessons
 } do


### PR DESCRIPTION
Fix for issue #159.
Use a callback to set a blank archive_url to the hangout_url whenever a lesson is saved.