### PR TITLE
Run bridge troll recorder worker from Application controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,7 +65,7 @@ class ApplicationController < ActionController::Base
     if current_user.last_badges_checked_at.nil? ||
        (Time.now - current_user.last_badges_checked_at > 3600)
       BadgeAllocator.perform_async(current_user.id)
-      BridgeTrollRecorder.perform_async
+      # BridgeTrollRecorder.perform_async
       current_user.last_badges_checked_at = Time.now
       current_user.save!
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ require_dependency "user_sanitizer"
 
 class ApplicationController < ActionController::Base
   before_filter :set_time_zone, :maybe_enqueue_codewars_recorder,
-                :maybe_enqueue_badge_allocator_or_bridge_troll_recorder
+                :maybe_enqueue_badge_allocator
 
   protect_from_forgery
   helper_method :current_school
@@ -60,7 +60,6 @@ class ApplicationController < ActionController::Base
   end
 
   private
-  # def maybe_enqueue_badge_allocator_or_bridge_troll_recorder
   def maybe_enqueue_badge_allocator
     return unless user_signed_in?
     if current_user.last_badges_checked_at.nil? ||

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,12 +60,13 @@ class ApplicationController < ActionController::Base
   end
 
   private
-  def maybe_enqueue_badge_allocator_or_bridge_troll_recorder
+  # def maybe_enqueue_badge_allocator_or_bridge_troll_recorder
+  def maybe_enqueue_badge_allocator
     return unless user_signed_in?
     if current_user.last_badges_checked_at.nil? ||
        (Time.now - current_user.last_badges_checked_at > 3600)
       BadgeAllocator.perform_async(current_user.id)
-      # BridgeTrollRecorder.perform_async
+      BridgeTrollRecorder.perform_async
       current_user.last_badges_checked_at = Time.now
       current_user.save!
     end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,6 +1,0 @@
-# Heroku scheduler file
-
-desc "Find BridgeTroll class counts for our users."
-task get_bridge_troll_class_count: :environment do
-  BridgeTrollRecorder.perform_async
-end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -82,7 +82,7 @@ describe ApplicationController do
     end
   end
 
-  describe "maybe_enqueue_badge_allocator_or_bridge_troll_recorder" do
+  describe "maybe_enqueue_badge_allocator" do
     before do
       Timecop.freeze
       controller.stub(:current_user).and_return user
@@ -93,7 +93,7 @@ describe ApplicationController do
 
       it "enqueues a badge allocation job and sets last_badges_checked_at" do
         BadgeAllocator.should_receive(:perform_async).with(user.id)
-        controller.send(:maybe_enqueue_badge_allocator_or_bridge_troll_recorder)
+        controller.send(:maybe_enqueue_badge_allocator)
         user.reload.last_badges_checked_at.to_i.should == Time.now.to_i
       end
     end
@@ -103,7 +103,7 @@ describe ApplicationController do
 
       it "enqueues a badge allocation job and sets last_badges_checked_at" do
         BadgeAllocator.should_receive(:perform_async).with(user.id)
-        controller.send(:maybe_enqueue_badge_allocator_or_bridge_troll_recorder)
+        controller.send(:maybe_enqueue_badge_allocator)
         user.reload.last_badges_checked_at.to_i.should == Time.now.to_i
       end
     end
@@ -113,39 +113,39 @@ describe ApplicationController do
 
       it "does not enqueue a badge allocation job or set last_badges_checked_at" do
         BadgeAllocator.should_not_receive(:perform_async)
-        controller.send(:maybe_enqueue_badge_allocator_or_bridge_troll_recorder)
+        controller.send(:maybe_enqueue_badge_allocator)
         user.reload.last_badges_checked_at.to_i.should == (Time.now-5.minutes).to_i
       end
     end
 
-    # context "current_user has never had a bridge troll recorded job" do
-    #   let(:user) { create(:user, last_badges_checked_at: nil) }
+    context "current_user has never had a bridge troll recorded job" do
+      let(:user) { create(:user, last_badges_checked_at: nil) }
 
-    #   it "enqueues a bridge troll recorder job and sets last_badges_checked_at" do
-    #     BridgeTrollRecorder.should_receive(:perform_async)
-    #     controller.send(:maybe_enqueue_badge_allocator_or_bridge_troll_recorder)
-    #     user.reload.last_badges_checked_at.to_i.should == Time.now.to_i
-    #   end
-    # end
+      it "enqueues a bridge troll recorder job and sets last_badges_checked_at" do
+        BridgeTrollRecorder.should_receive(:perform_async)
+        controller.send(:maybe_enqueue_badge_allocator)
+        user.reload.last_badges_checked_at.to_i.should == Time.now.to_i
+      end
+    end
 
-    # context "current_user has had a bridge troll recorded job 2 hours ago" do
-    #   let(:user) { create(:user, last_badges_checked_at: Time.now-2.hours.ago) }
+    context "current_user has had a bridge troll recorded job 2 hours ago" do
+      let(:user) { create(:user, last_badges_checked_at: Time.now-2.hours.ago) }
 
-    #   it "enqueues a bridge troll recorder job and sets last_badges_checked_at" do
-    #     BridgeTrollRecorder.should_receive(:perform_async)
-    #     controller.send(:maybe_enqueue_badge_allocator_or_bridge_troll_recorder)
-    #     user.reload.last_badges_checked_at.to_i.should == Time.now.to_i
-    #   end
-    # end
+      it "enqueues a bridge troll recorder job and sets last_badges_checked_at" do
+        BridgeTrollRecorder.should_receive(:perform_async)
+        controller.send(:maybe_enqueue_badge_allocator)
+        user.reload.last_badges_checked_at.to_i.should == Time.now.to_i
+      end
+    end
 
-    # context "current_user had a bridge troll recorded job 5 minutes ago" do
-    #   let(:user) { create(:user, last_badges_checked_at: Time.now-5.minutes) }
+    context "current_user had a bridge troll recorded job 5 minutes ago" do
+      let(:user) { create(:user, last_badges_checked_at: Time.now-5.minutes) }
 
-    #   it "does not enqueue a bridge troll recorder job or set last_badges_checked_at" do
-    #     BridgeTrollRecorder.should_not_receive(:perform_async)
-    #     controller.send(:maybe_enqueue_badge_allocator_or_bridge_troll_recorder)
-    #     user.reload.last_badges_checked_at.to_i.should == (Time.now-5.minutes).to_i
-    #   end
-    # end
+      it "does not enqueue a bridge troll recorder job or set last_badges_checked_at" do
+        BridgeTrollRecorder.should_not_receive(:perform_async)
+        controller.send(:maybe_enqueue_badge_allocator)
+        user.reload.last_badges_checked_at.to_i.should == (Time.now-5.minutes).to_i
+      end
+    end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -118,34 +118,34 @@ describe ApplicationController do
       end
     end
 
-    context "current_user has never had a bridge troll recorded job" do
-      let(:user) { create(:user, last_badges_checked_at: nil) }
+    # context "current_user has never had a bridge troll recorded job" do
+    #   let(:user) { create(:user, last_badges_checked_at: nil) }
 
-      it "enqueues a bridge troll recorder job and sets last_badges_checked_at" do
-        BridgeTrollRecorder.should_receive(:perform_async)
-        controller.send(:maybe_enqueue_badge_allocator_or_bridge_troll_recorder)
-        user.reload.last_badges_checked_at.to_i.should == Time.now.to_i
-      end
-    end
+    #   it "enqueues a bridge troll recorder job and sets last_badges_checked_at" do
+    #     BridgeTrollRecorder.should_receive(:perform_async)
+    #     controller.send(:maybe_enqueue_badge_allocator_or_bridge_troll_recorder)
+    #     user.reload.last_badges_checked_at.to_i.should == Time.now.to_i
+    #   end
+    # end
 
-    context "current_user has had a bridge troll recorded job 2 hours ago" do
-      let(:user) { create(:user, last_badges_checked_at: Time.now-2.hours.ago) }
+    # context "current_user has had a bridge troll recorded job 2 hours ago" do
+    #   let(:user) { create(:user, last_badges_checked_at: Time.now-2.hours.ago) }
 
-      it "enqueues a bridge troll recorder job and sets last_badges_checked_at" do
-        BridgeTrollRecorder.should_receive(:perform_async)
-        controller.send(:maybe_enqueue_badge_allocator_or_bridge_troll_recorder)
-        user.reload.last_badges_checked_at.to_i.should == Time.now.to_i
-      end
-    end
+    #   it "enqueues a bridge troll recorder job and sets last_badges_checked_at" do
+    #     BridgeTrollRecorder.should_receive(:perform_async)
+    #     controller.send(:maybe_enqueue_badge_allocator_or_bridge_troll_recorder)
+    #     user.reload.last_badges_checked_at.to_i.should == Time.now.to_i
+    #   end
+    # end
 
-    context "current_user had a bridge troll recorded job 5 minutes ago" do
-      let(:user) { create(:user, last_badges_checked_at: Time.now-5.minutes) }
+    # context "current_user had a bridge troll recorded job 5 minutes ago" do
+    #   let(:user) { create(:user, last_badges_checked_at: Time.now-5.minutes) }
 
-      it "does not enqueue a bridge troll recorder job or set last_badges_checked_at" do
-        BridgeTrollRecorder.should_not_receive(:perform_async)
-        controller.send(:maybe_enqueue_badge_allocator_or_bridge_troll_recorder)
-        user.reload.last_badges_checked_at.to_i.should == (Time.now-5.minutes).to_i
-      end
-    end
+    #   it "does not enqueue a bridge troll recorder job or set last_badges_checked_at" do
+    #     BridgeTrollRecorder.should_not_receive(:perform_async)
+    #     controller.send(:maybe_enqueue_badge_allocator_or_bridge_troll_recorder)
+    #     user.reload.last_badges_checked_at.to_i.should == (Time.now-5.minutes).to_i
+    #   end
+    # end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -99,7 +99,9 @@ describe ApplicationController do
     end
 
     context "current_user has had a badge allocation job 2 hours ago" do
-      let(:user) { create(:user, last_badges_checked_at: Time.now-2.hours.ago) }
+      let(:user) do
+        create(:user, last_badges_checked_at: Time.now - 2.hours.ago)
+      end
 
       it "enqueues a badge allocation job and sets last_badges_checked_at" do
         BadgeAllocator.should_receive(:perform_async).with(user.id)
@@ -109,19 +111,24 @@ describe ApplicationController do
     end
 
     context "current_user had a badge allocation job 5 minutes ago" do
-      let(:user) { create(:user, last_badges_checked_at: Time.now-5.minutes) }
+      let(:user) do
+        create(:user, last_badges_checked_at: Time.now - 5.minutes)
+      end
 
-      it "does not enqueue a badge allocation job or set last_badges_checked_at" do
+      it "does not enqueue a badge allocation job or set"\
+        " last_badges_checked_at" do
         BadgeAllocator.should_not_receive(:perform_async)
         controller.send(:maybe_enqueue_badge_allocator)
-        user.reload.last_badges_checked_at.to_i.should == (Time.now-5.minutes).to_i
+        user.reload.last_badges_checked_at.to_i.should ==
+          (Time.now - 5.minutes).to_i
       end
     end
 
     context "current_user has never had a bridge troll recorded job" do
       let(:user) { create(:user, last_badges_checked_at: nil) }
 
-      it "enqueues a bridge troll recorder job and sets last_badges_checked_at" do
+      it "enqueues a bridge troll recorder job and sets"\
+        " last_badges_checked_at" do
         BridgeTrollRecorder.should_receive(:perform_async)
         controller.send(:maybe_enqueue_badge_allocator)
         user.reload.last_badges_checked_at.to_i.should == Time.now.to_i
@@ -129,9 +136,12 @@ describe ApplicationController do
     end
 
     context "current_user has had a bridge troll recorded job 2 hours ago" do
-      let(:user) { create(:user, last_badges_checked_at: Time.now-2.hours.ago) }
+      let(:user) do
+        create(:user, last_badges_checked_at: Time.now - 2.hours.ago)
+      end
 
-      it "enqueues a bridge troll recorder job and sets last_badges_checked_at" do
+      it "enqueues a bridge troll recorder job and sets"\
+        " last_badges_checked_at" do
         BridgeTrollRecorder.should_receive(:perform_async)
         controller.send(:maybe_enqueue_badge_allocator)
         user.reload.last_badges_checked_at.to_i.should == Time.now.to_i
@@ -139,12 +149,16 @@ describe ApplicationController do
     end
 
     context "current_user had a bridge troll recorded job 5 minutes ago" do
-      let(:user) { create(:user, last_badges_checked_at: Time.now-5.minutes) }
+      let(:user) do
+        create(:user, last_badges_checked_at: Time.now - 5.minutes)
+      end
 
-      it "does not enqueue a bridge troll recorder job or set last_badges_checked_at" do
+      it "does not enqueue a bridge troll recorder job or set"\
+        " last_badges_checked_at" do
         BridgeTrollRecorder.should_not_receive(:perform_async)
         controller.send(:maybe_enqueue_badge_allocator)
-        user.reload.last_badges_checked_at.to_i.should == (Time.now-5.minutes).to_i
+        user.reload.last_badges_checked_at.to_i.should ==
+          (Time.now - 5.minutes).to_i
       end
     end
   end


### PR DESCRIPTION
Remove the rake task that was run from a Heroku scheduler to run the
bridge troll recorder worker. Run the bridge troll recorder worker from
the same place as the badge allocator worker (in the application
controller.)
Include tests for running the bridge troll recorder from the application
controller.