### PR TITLE
Adjust Geocoder Range

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,7 +31,7 @@ class ApplicationController < ActionController::Base
     unless @current_school
       begin
         loc = request.location
-        @current_school = Venue.near([loc.latitude, loc.longitude], 5000)
+        @current_school = Venue.near([loc.latitude, loc.longitude], 1400)
                                .first
                                .school
       rescue StandardError


### PR DESCRIPTION
Change the range used to find schools near a user from 5000 to 1400 so
users will be matched to one of the two current schools (in San Francisco
and Charlottesville, VA). The 1400 miles range was picked to split the
distance between San Francisco and Charlottesville, VA.

This could solve one of the problems with geocoding mentioned in #59