### PR TITLE
Filter lessons by school

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -14,7 +14,7 @@ class HomeController < ApplicationController
 
   def index
     @lessons_this_month = Lesson.for_school_id(current_school.id)
-      .lessons_this_month
+                          .lessons_this_month
     @past_lessons = Lesson.for_school_id(current_school.id).past_lessons
     @future_lessons = Lesson.for_school_id(current_school.id).future_lessons
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -14,7 +14,7 @@ class HomeController < ApplicationController
 
   def index
     @lessons_this_month = Lesson.for_school_id(current_school.id)
-                          .lessons_this_month
+                            .lessons_this_month
     @past_lessons = Lesson.for_school_id(current_school.id).past_lessons
     @future_lessons = Lesson.for_school_id(current_school.id).future_lessons
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -13,9 +13,9 @@ class HomeController < ApplicationController
   end
 
   def index
-    @lessons_this_month = Lesson.for_school(current_school).lessons_this_month
-    @past_lessons = Lesson.for_school(current_school).past_lessons
-    @future_lessons = Lesson.for_school(current_school).future_lessons
+    @lessons_this_month = Lesson.for_school_id(current_school.id).lessons_this_month
+    @past_lessons = Lesson.for_school_id(current_school.id).past_lessons
+    @future_lessons = Lesson.for_school_id(current_school.id).future_lessons
   end
 
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -13,7 +13,8 @@ class HomeController < ApplicationController
   end
 
   def index
-    @lessons_this_month = Lesson.for_school_id(current_school.id).lessons_this_month
+    @lessons_this_month = Lesson.for_school_id(current_school.id)
+      .lessons_this_month
     @past_lessons = Lesson.for_school_id(current_school.id).past_lessons
     @future_lessons = Lesson.for_school_id(current_school.id).future_lessons
   end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -9,7 +9,8 @@ class LessonsController < ApplicationController
   # GET /lessons.json
   def index
     if params[:school].present?
-      @lessons = Lesson.for_school_id(current_school.id).order("start_time DESC")
+      @lessons = Lesson.for_school_id(current_school.id)
+        .order("start_time DESC")
       @title = "All lessons in #{current_school.name}"
     else
       @lessons = Lesson.order("start_time DESC")
@@ -109,7 +110,6 @@ class LessonsController < ApplicationController
     if params[:school_id].present?
       future_lessons = future_lesson.for_school_id(params[:school_id])
     end
-
     render json: future_lessons.pluck(:slug)
   end
 
@@ -119,7 +119,6 @@ class LessonsController < ApplicationController
     if params[:school_id].present?
       next_lessons = next_lessons.for_school_id(params[:school_id])
     end
-    
     render json: next_lessons.first
   end
 

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -9,7 +9,7 @@ class LessonsController < ApplicationController
   # GET /lessons.json
   def index
     if params[:school].present?
-      @lessons = Lesson.for_school(current_school).order("start_time DESC")
+      @lessons = Lesson.for_school_id(current_school.id).order("start_time DESC")
       @title = "All lessons in #{current_school.name}"
     else
       @lessons = Lesson.order("start_time DESC")
@@ -105,16 +105,22 @@ class LessonsController < ApplicationController
 
   # GET /l/future/slugs.json
   def future_lessons_slug
-    school = School.find_by(id: params[:school_id])
-    future_lesson_slugs = Lesson.future_lessons_for_school(school).pluck(:slug)
-    render json: future_lesson_slugs
+    future_lessons = Lesson.future_lessons
+    if params[:school_id].present?
+      future_lessons = future_lesson.for_school_id(params[:school_id])
+    end
+
+    render json: future_lessons.pluck(:slug)
   end
 
   # GET /l/upcoming.json
   def upcoming
-    school = School.find_by(id: params[:school_id])
-    next_lesson = Lesson.future_lessons_for_school(school).first
-    render json: next_lesson
+    next_lessons = Lesson.future_lessons
+    if params[:school_id].present?
+      next_lessons = next_lessons.for_school_id(params[:school_id])
+    end
+    
+    render json: next_lessons.first
   end
 
   # GET /attending_lesson/:lesson_slug.json

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -105,13 +105,15 @@ class LessonsController < ApplicationController
 
   # GET /l/future/slugs.json
   def future_lessons_slug
-    future_lesson_slugs = Lesson.future_lessons.pluck(:slug)
+    school = School.find_by(id: params[:school_id])
+    future_lesson_slugs = Lesson.future_lessons_for_school(school).pluck(:slug)
     render json: future_lesson_slugs
   end
 
   # GET /l/upcoming.json
   def upcoming
-    next_lesson = Lesson.future_lessons.first
+    school = School.find_by(id: params[:school_id])
+    next_lesson = Lesson.future_lessons_for_school(school).first
     render json: next_lesson
   end
 

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -10,7 +10,7 @@ class LessonsController < ApplicationController
   def index
     if params[:school].present?
       @lessons = Lesson.for_school_id(current_school.id)
-                 .order("start_time DESC")
+                   .order("start_time DESC")
       @title = "All lessons in #{current_school.name}"
     else
       @lessons = Lesson.order("start_time DESC")

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -10,7 +10,7 @@ class LessonsController < ApplicationController
   def index
     if params[:school].present?
       @lessons = Lesson.for_school_id(current_school.id)
-        .order("start_time DESC")
+                 .order("start_time DESC")
       @title = "All lessons in #{current_school.name}"
     else
       @lessons = Lesson.order("start_time DESC")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
     authorize! :notify, lesson
 
     school = lesson.venue.school
-    next_up_lesson = Lesson.for_school(school).future_lessons.first
+    next_up_lesson = Lesson.for_school_id(school.id).future_lessons.first
 
     if next_up_lesson == lesson
       User.where(subscribe_lesson_notifications: true,

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -46,8 +46,8 @@ class Lesson < ActiveRecord::Base
     lessons
   end
 
-  def self.for_school(school)
-    self.joins(:venue).where(venues: {school_id: school.id})
+  def self.for_school_id(school_id)
+    self.joins(:venue).where(venues: {school_id: school_id})
   end
 
   def to_ics
@@ -75,14 +75,5 @@ class Lesson < ActiveRecord::Base
 
   def as_json(opts={})
     super.merge(opts.slice(:students))
-  end
-
-  def self.future_lessons_for_school(school = nil)
-    if school
-      Lesson.for_school(school).where("end_time > (?)", Time.current)
-        .order("start_time asc")
-    else
-      Lesson.future_lessons
-    end
   end
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -76,4 +76,13 @@ class Lesson < ActiveRecord::Base
   def as_json(opts={})
     super.merge(opts.slice(:students))
   end
+
+  def self.future_lessons_for_school(school = nil)
+    if school
+      Lesson.for_school(school).where("end_time > (?)", Time.current)
+        .order("start_time asc")
+    else
+      Lesson.future_lessons
+    end
+  end
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -47,7 +47,7 @@ class Lesson < ActiveRecord::Base
   end
 
   def self.for_school_id(school_id)
-    self.joins(:venue).where(venues: {school_id: school_id})
+    self.joins(:venue).where(venues: { school_id: school_id })
   end
 
   def to_ics

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,9 +23,9 @@ Rs::Application.routes.draw do
       get "whiteboard" => "lessons#show", :whiteboard => true
     end
     collection do
-      get "future/slugs", to: "lessons#future_lessons_slug",
-                          as: :future_slug
-      get "upcoming", to: "lessons#upcoming", as: :upcoming
+      get "future/slugs(/:school_id)", to: "lessons#future_lessons_slug",
+                                       as: :future_slug
+      get "upcoming(/:school_id)", to: "lessons#upcoming", as: :upcoming
     end
     resources :notifications, only: [:new, :create]
   end

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -78,4 +78,43 @@ describe Lesson do
       Lesson.for_school(school).should_not include(venue1)
     end
   end
+
+  describe "future_lessons_for_school" do
+    let(:school1) { create(:school) }
+    let(:school2) { create(:school) }
+    let(:venue1)  { create(:venue, school: school1) }
+    let(:venue2)  { create(:venue, school: school2) }
+    let(:lesson1) { create(:lesson, venue: venue1, title: "Lesson 1") }
+    let(:lesson2) { create(:lesson, venue: venue2, title: "Lesson 2") }
+    let(:lesson3) { create(:lesson, venue: venue1, title: "Lesson 3") }
+    let(:past_lesson) do
+      create(:lesson, venue: venue1, start_time: Time.now - 1.day,
+        end_time: Time.now - 1.day + 2.hours)
+    end
+
+    context "with school provided" do
+      let(:lessons) { Lesson.future_lessons_for_school(school1) }
+
+      it "does not include lesson at a different school" do
+        expect(lessons).not_to include(lesson2)
+      end
+      it "does not include past lesson" do 
+        expect(lessons).not_to include(past_lesson)
+      end
+      it "includes future lessons at school provided" do
+        expect(lessons).to match_array([lesson1, lesson3])
+      end
+    end
+
+    context "with no school provided" do
+      let(:lessons) { Lesson.future_lessons_for_school }
+
+      it "does not include past lesson" do 
+        expect(lessons).not_to include(past_lesson)
+      end
+      it "includes all future lessons" do
+        expect(lessons).to match_array([lesson1, lesson2, lesson3])
+      end
+    end
+  end
 end

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -82,8 +82,8 @@ describe Lesson do
   describe "future_lessons_for_school" do
     let(:school1) { create(:school) }
     let(:school2) { create(:school) }
-    let(:venue1)  { create(:venue, school: school1) }
-    let(:venue2)  { create(:venue, school: school2) }
+    let(:venue1) { create(:venue, school: school1) }
+    let(:venue2) { create(:venue, school: school2) }
     let(:lesson1) { create(:lesson, venue: venue1, title: "Lesson 1") }
     let(:lesson2) { create(:lesson, venue: venue2, title: "Lesson 2") }
     let(:lesson3) { create(:lesson, venue: venue1, title: "Lesson 3") }
@@ -98,7 +98,7 @@ describe Lesson do
       it "does not include lesson at a different school" do
         expect(lessons).not_to include(lesson2)
       end
-      it "does not include past lesson" do 
+      it "does not include past lesson" do
         expect(lessons).not_to include(past_lesson)
       end
       it "includes future lessons at school provided" do
@@ -109,7 +109,7 @@ describe Lesson do
     context "with no school provided" do
       let(:lessons) { Lesson.future_lessons_for_school }
 
-      it "does not include past lesson" do 
+      it "does not include past lesson" do
         expect(lessons).not_to include(past_lesson)
       end
       it "includes all future lessons" do

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -59,7 +59,7 @@ describe Lesson do
 
   end
 
-  describe "for_school" do
+  describe "for_school_id" do
     it "contains lessons for venues in the school" do
       school = create(:school)
       venue1 = create(:venue, school: school)
@@ -67,7 +67,7 @@ describe Lesson do
       lesson1 = create(:lesson, venue: venue1)
       lesson2 = create(:lesson, venue: venue2)
 
-      lessons = Lesson.for_school(school)
+      lessons = Lesson.for_school_id(school.id)
       lessons.should include(lesson1)
       lessons.should include(lesson2)
     end
@@ -75,46 +75,7 @@ describe Lesson do
     it "doesn't contains lessons for venues outside the school" do
       school = create(:school)
       venue1 = create(:venue)
-      Lesson.for_school(school).should_not include(venue1)
-    end
-  end
-
-  describe "future_lessons_for_school" do
-    let(:school1) { create(:school) }
-    let(:school2) { create(:school) }
-    let(:venue1) { create(:venue, school: school1) }
-    let(:venue2) { create(:venue, school: school2) }
-    let(:lesson1) { create(:lesson, venue: venue1, title: "Lesson 1") }
-    let(:lesson2) { create(:lesson, venue: venue2, title: "Lesson 2") }
-    let(:lesson3) { create(:lesson, venue: venue1, title: "Lesson 3") }
-    let(:past_lesson) do
-      create(:lesson, venue: venue1, start_time: Time.now - 1.day,
-        end_time: Time.now - 1.day + 2.hours)
-    end
-
-    context "with school provided" do
-      let(:lessons) { Lesson.future_lessons_for_school(school1) }
-
-      it "does not include lesson at a different school" do
-        expect(lessons).not_to include(lesson2)
-      end
-      it "does not include past lesson" do
-        expect(lessons).not_to include(past_lesson)
-      end
-      it "includes future lessons at school provided" do
-        expect(lessons).to match_array([lesson1, lesson3])
-      end
-    end
-
-    context "with no school provided" do
-      let(:lessons) { Lesson.future_lessons_for_school }
-
-      it "does not include past lesson" do
-        expect(lessons).not_to include(past_lesson)
-      end
-      it "includes all future lessons" do
-        expect(lessons).to match_array([lesson1, lesson2, lesson3])
-      end
+      Lesson.for_school_id(school.id).should_not include(venue1)
     end
   end
 end


### PR DESCRIPTION
For the `/l/future/slugs` and `/l/upcoming` API endpoints, allow for an
optional :school_id at the end of the url and return only lesson(s) at
the school whose id is passed.
Move the logic for getting the lesson(s), dependent on if a school is
specified, to the lesson model and include tests for the new method used.