### PR TITLE
Validate Tweet Message Length

### DIFF
--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -50,7 +50,6 @@ class LessonsController < ApplicationController
   # GET /lessons/new.json
   def new
     # @lesson = Lesson.new
-    @venues = current_school.venues
 
     respond_to do |format|
       format.html # new.html.erb
@@ -60,7 +59,6 @@ class LessonsController < ApplicationController
 
   # GET /lessons/1/edit
   def edit
-    @venues = current_school.venues
   end
 
   # POST /lessons
@@ -73,10 +71,7 @@ class LessonsController < ApplicationController
         format.html { redirect_to @lesson, notice: 'Lesson was successfully created.' }
         format.json { render json: @lesson, status: :created, location: @lesson }
       else
-        format.html do
-          @venues = current_school.venues
-          render action: "new"
-        end
+        format.html { render action: "new" }
         format.json { render json: @lesson.errors, status: :unprocessable_entity }
       end
     end
@@ -90,10 +85,7 @@ class LessonsController < ApplicationController
         format.html { redirect_to @lesson, notice: 'Lesson was successfully updated.' }
         format.json { head :no_content }
       else
-        format.html do
-          @venues = current_school.venues
-          render action: "edit"
-        end
+        format.html { render action: "edit" }
         format.json { render json: @lesson.errors, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -73,7 +73,10 @@ class LessonsController < ApplicationController
         format.html { redirect_to @lesson, notice: 'Lesson was successfully created.' }
         format.json { render json: @lesson, status: :created, location: @lesson }
       else
-        format.html { render action: "new" }
+        format.html do
+          @venues = current_school.venues
+          render action: "new"
+        end
         format.json { render json: @lesson.errors, status: :unprocessable_entity }
       end
     end
@@ -87,7 +90,10 @@ class LessonsController < ApplicationController
         format.html { redirect_to @lesson, notice: 'Lesson was successfully updated.' }
         format.json { head :no_content }
       else
-        format.html { render action: "edit" }
+        format.html do
+          @venues = current_school.venues
+          render action: "edit"
+        end
         format.json { render json: @lesson.errors, status: :unprocessable_entity }
       end
     end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -8,6 +8,8 @@ class Lesson < ActiveRecord::Base
   belongs_to :venue
   belongs_to :teacher, class_name: "User"
 
+  validates :tweet_message, length: { maximum: 140 }
+
   def generate_slug
     self.slug = Slug.new(title).generate if self.slug.blank?
   end

--- a/app/views/lessons/_form.html.haml
+++ b/app/views/lessons/_form.html.haml
@@ -41,8 +41,9 @@
     %input{id: "lesson_end_time", name: "lesson[end_time]", type: "time",
      value: @lesson.end_time ? @lesson.end_time.strftime("%H:%M") : "21:00"}
   .field
+    - venues = current_school.venues
     = f.label :venue_id
-    =select("lesson", "venue_id", @venues.collect {|v| [ v.name, v.id ]})
+    =select("lesson", "venue_id", venues.collect {|v| [ v.name, v.id ]})
   %br
   .field
     = f.label :slug

--- a/lib/lesson_tweeter.rb
+++ b/lib/lesson_tweeter.rb
@@ -13,6 +13,8 @@ class LessonTweeter
     else
       status += " - #{url}"
     end
+    return false if status.length > 140
+    
     begin
       client = Twitter::REST::Client.new do |config|
         config.consumer_key = ENV['TWITTER_CONSUMER_KEY']

--- a/lib/lesson_tweeter.rb
+++ b/lib/lesson_tweeter.rb
@@ -14,7 +14,7 @@ class LessonTweeter
       status += " - #{url}"
     end
     return false if status.length > 140
-    
+
     begin
       client = Twitter::REST::Client.new do |config|
         config.consumer_key = ENV['TWITTER_CONSUMER_KEY']

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -2,6 +2,13 @@ require 'spec_helper'
 
 describe Lesson do
 
+  describe "validation" do
+    let(:lesson) { create(:lesson) }
+    subject { lesson }
+
+    it { should validate_length_of(:tweet_message).is_at_most(140) }
+  end
+
   describe "lessons_this_month" do
     it "contains this months's lessons" do
       Timecop.freeze(Time.local(2014,7,1,12,0,0)) do


### PR DESCRIPTION
Fix for issue #173 
Add validation setting a maximum length of 140 for the tweet message on
lesson create and update. Include test and modify controller to handle
a lesson that fails validation.

Check the final tweet message composed in `tweet` method of
`lib/lesson_tweeter.rb`, ensuring that a tweet is not sent if the final
composed tweet message exceeds 140 characters.