### PR TITLE
Fix User's as_json method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,7 +80,7 @@ class User < ActiveRecord::Base
                                :codewars_username,
                                :homepage,
                                :github_username] }
-    super(default_options.merge! options)
+    super(default_options.merge options)
   end
 
   def self.rails_bridge_users

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,15 +72,15 @@ class User < ActiveRecord::Base
   end
 
   def as_json(options = {})
-    options ||= { only: [:id,
-                         :created_at,
-                         :teacher,
-                         :school_id,
-                         :admin,
-                         :codewars_username,
-                         :homepage,
-                         :github_username] }
-    super options
+    default_options = { only: [:id,
+                               :created_at,
+                               :teacher,
+                               :school_id,
+                               :admin,
+                               :codewars_username,
+                               :homepage,
+                               :github_username] }
+    super(default_options.merge! options)
   end
 
   def self.rails_bridge_users


### PR DESCRIPTION
Fix `as_json` method to merge options hash, if provided, into a default
options hash, giving priority to the passed in options hash.