### PR TITLE
Issue 188 "Can't see poll results after refreshing page"

### DIFF
--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -1,4 +1,7 @@
 class PollsController < ApplicationController
+
+  before_action :authenticate_user!
+
   # GET /polls
   # GET /polls.json
   def index

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -3,8 +3,7 @@
     %h2 Past Workshops
     =render "lessons/past_lessons", :lessons => @past_lessons
   - if current_user
-    = render :partial => "polls/poll", :locals => {poll: current_user.next_unanswered_poll, previous_poll: nil}
-
+    = render :partial => "polls/poll", :locals => {poll: current_user.next_unanswered_poll, last_completed_poll: Poll.last}
 .announce
   - if @future_lessons.present?
     = render "lessons/announce", :lesson => @future_lessons.first, :main_page => true

--- a/app/views/lessons/show.html.haml
+++ b/app/views/lessons/show.html.haml
@@ -18,7 +18,7 @@
         - @lesson.users.each do |u|
           = render partial: "users/single_user", locals: {user: u, lesson: @lesson}
   - if user_signed_in?
-    = render partial: "polls/poll", locals: {poll: current_user.next_unanswered_poll, previous_poll: nil}
+    = render partial: "polls/poll", locals: {poll: current_user.next_unanswered_poll, last_completed_poll: nil}
 
 .lesson_details
   =render partial: "lessons/announce", locals: {lesson: @lesson, main_page: false}

--- a/app/views/polls/_poll.html.haml
+++ b/app/views/polls/_poll.html.haml
@@ -1,37 +1,26 @@
--if user_signed_in?
-  -poll = current_user.next_unanswered_poll
-  -if poll.present?
-    .polls{'data-id' => poll.id}
-      -if poll.present?
-        %h2 Poll:#{poll.question}
-        /%p=poll.description
+-poll = current_user.next_unanswered_poll
+-if poll.present?
+  .polls{'data-id' => poll.id}
+    -if poll.present?
+      %h2 Poll:#{poll.question}
+      /%p=poll.description
 
-        -answers = poll.answers
-        -answer = UserAnswer.new
-        -answer.user_id = current_user.id
-        = form_for :answer, :url => "/polls/answer", :remote => true do |f|
-          %ul
-            -answers.each do |answer|
-              = answer_list_item(f, answer).html_safe
-          = f.hidden_field :poll_id, :value => poll.id
-          = f.submit "Vote", :class => "small_button"
-  -else
-    .polls
-      %h2 Polls
-      Please watch the statistics
-
-  -if previous_poll.present?
-    .poll-result
-      %p Poll result
-      %h3=previous_poll.try(:question)
-      =render :partial => 'polls/stats', :locals => {:poll => previous_poll}
-
+      -answers = poll.answers
+      -answer = UserAnswer.new
+      -answer.user_id = current_user.id
+      = form_for :answer, :url => "/polls/answer", :remote => true do |f|
+        %ul
+          -answers.each do |answer|
+            = answer_list_item(f, answer).html_safe
+        = f.hidden_field :poll_id, :value => poll.id
+        = f.submit "Vote", :class => "small_button"
 -else
   .polls
     %h2 Polls
-    Please
-    %a{:href => "#", "data-reveal-id" => "LoginModal"} sign in
+    Please watch the statistics
 
-
-
-
+-if previous_poll.present?
+  .poll-result
+    %p Poll result
+    %h3=previous_poll.try(:question)
+    =render :partial => 'polls/stats', :locals => {:poll => previous_poll}

--- a/app/views/polls/_poll.html.haml
+++ b/app/views/polls/_poll.html.haml
@@ -14,13 +14,10 @@
             = answer_list_item(f, answer).html_safe
         = f.hidden_field :poll_id, :value => poll.id
         = f.submit "Vote", :class => "small_button"
--else
-  .polls
-    %h2 Polls
-    Please watch the statistics
-
--if previous_poll.present?
+-elsif last_completed_poll.present?
   .poll-result
     %p Poll result
-    %h3=previous_poll.try(:question)
-    =render :partial => 'polls/stats', :locals => {:poll => previous_poll}
+    %h3=last_completed_poll.try(:question)
+    =render :partial => 'polls/stats', :locals => {:poll => last_completed_poll}
+    %br
+    = link_to 'See all polls', polls_path

--- a/spec/acceptance/polls_spec.rb
+++ b/spec/acceptance/polls_spec.rb
@@ -46,6 +46,7 @@ feature %q{
 
   background do
     stub_current_school
+    FactoryGirl.create(:poll)
     @user = FactoryGirl.create(:user)
     sign_in_manually(@user)
   end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -61,4 +61,9 @@ FactoryGirl.define do
     sequence(:language) { |i| "language-#{i}"}
   end
 
+  factory :poll do
+    question "Am I stubby?"
+    published true
+  end
+
 end


### PR DESCRIPTION
Unanswered polls are presented to the user when viewing site index (after authentication).
If a user has completed all polls, the most recently created poll results are shown instead.

*No functional tests were written in this patch series.