### PR TITLE
Closes #199

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -6,8 +6,6 @@ class Lesson < ActiveRecord::Base
   belongs_to :venue
   belongs_to :teacher, class_name: "User"
 
-  
-
   def generate_slug
     self.slug = Slug.new(title).generate if self.slug.blank?
   end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -6,7 +6,7 @@ class Lesson < ActiveRecord::Base
   belongs_to :venue
   belongs_to :teacher, class_name: "User"
 
-  validates :tweet_message, length: { maximum: 140 }
+  
 
   def generate_slug
     self.slug = Slug.new(title).generate if self.slug.blank?

--- a/db/migrate/20160317232856_remove_tweet_length_constraint.rb
+++ b/db/migrate/20160317232856_remove_tweet_length_constraint.rb
@@ -1,0 +1,5 @@
+class RemoveTweetLengthConstraint < ActiveRecord::Migration
+  def change
+    change_column :lessons, :tweet_message, :string, limit: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150918142651) do
+ActiveRecord::Schema.define(version: 20160317232856) do
 
   create_table "answers", force: :cascade do |t|
     t.datetime "created_at"
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 20150918142651) do
     t.datetime "start_time"
     t.datetime "end_time"
     t.datetime "notification_sent_at"
-    t.string   "tweet_message",               limit: 140
+    t.string   "tweet_message"
     t.integer  "teacher_id"
     t.string   "image_social"
     t.string   "codewars_challenge_slug"

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -6,7 +6,7 @@ describe Lesson do
     let(:lesson) { create(:lesson) }
     subject { lesson }
 
-    #previous behavior limited tweets to 140
+    # previous behavior limited tweets to 140
     describe "tweet_message length" do
       it "allows tweets of 255 characters" do
         tweet = "a" * 255

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -6,7 +6,14 @@ describe Lesson do
     let(:lesson) { create(:lesson) }
     subject { lesson }
 
-    it { should validate_length_of(:tweet_message).is_at_most(140) }
+    #previous behavior limited tweets to 140
+    describe "tweet_message length" do
+      it "allows tweets of 255 characters" do
+        tweet = "a" * 255
+        lesson.tweet_message = tweet
+        expect(lesson).to be_valid
+      end
+    end
   end
 
   describe "lessons_this_month" do


### PR DESCRIPTION
Removed 140 character limit from tweet_message column in the lessons tables