### PR TITLE
Fixes view for users on /polls page

### DIFF
--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -1,6 +1,6 @@
 class PollsController < ApplicationController
-  
-  load_and_authorize_resource only: [:new, :create, :edit, :update]
+
+  load_and_authorize_resource only: [:new, :create, :edit, :update, :destroy, :published]
   before_action :authenticate_user!
 
   # GET /polls

--- a/app/views/answers/index.html.haml
+++ b/app/views/answers/index.html.haml
@@ -15,9 +15,10 @@
       %td= answer.question_id
       %td= answer.text
       %td= link_to 'Show', answer
-      %td= link_to 'Edit', edit_answer_path(answer)
-      %td= link_to 'Destroy', answer, method: :delete, data: { confirm: 'Are you sure?' }
-
+      = if can? :manage, :polls
+        %td= link_to 'Edit', edit_answer_path(answer) 
+        %td= link_to 'Destroy', answer, method: :delete, data: { confirm: 'Are you sure?' }
+        
 %br
 
 = link_to 'New Answer', new_answer_path

--- a/app/views/answers/show.html.haml
+++ b/app/views/answers/show.html.haml
@@ -11,5 +11,5 @@
   = @answer.text
 
 = link_to 'Edit', edit_answer_path(@answer)
-\|
+
 = link_to 'Back', answers_path

--- a/app/views/polls/index.html.haml
+++ b/app/views/polls/index.html.haml
@@ -12,4 +12,5 @@
       	= link_to 'Edit', edit_poll_path(poll) 
       	= link_to 'Destroy', poll, method: :delete, data: { confirm: 'Are you sure?' } 
 
-= link_to 'New Poll', new_poll_path if can? :manage, :polls
+	= link_to "New Poll", new_poll_path if can? :manage, :polls
+=#may need to untab after testing in circle. Problem is rspec test is not seeing "New Poll" anywhere on index polls page.

--- a/app/views/polls/index.html.haml
+++ b/app/views/polls/index.html.haml
@@ -1,6 +1,6 @@
 %h1 Listing polls
 
-
+= link_to "New Poll", new_poll_path 
 -@polls.each do |poll|
   .poll{'data-id' => poll.id}
     %h2= poll.question
@@ -11,5 +11,3 @@
       = if can? :manage, :polls
       	= link_to 'Edit', edit_poll_path(poll) 
       	= link_to 'Destroy', poll, method: :delete, data: { confirm: 'Are you sure?' } 
-
-= link_to "New Poll", new_poll_path if can? :manage, :polls

--- a/app/views/polls/index.html.haml
+++ b/app/views/polls/index.html.haml
@@ -12,5 +12,4 @@
       	= link_to 'Edit', edit_poll_path(poll) 
       	= link_to 'Destroy', poll, method: :delete, data: { confirm: 'Are you sure?' } 
 
-	= link_to "New Poll", new_poll_path if can? :manage, :polls
-=#may need to untab after testing in circle. Problem is rspec test is not seeing "New Poll" anywhere on index polls page.
+= link_to "New Poll", new_poll_path if can? :manage, :polls

--- a/app/views/polls/index.html.haml
+++ b/app/views/polls/index.html.haml
@@ -8,7 +8,8 @@
       =render :partial => "polls/publish_link", :locals => {:poll => poll}
     .actions
       = link_to 'Show', poll
-      = link_to 'Edit', edit_poll_path(poll) 
-      = link_to 'Destroy', poll, method: :delete, data: { confirm: 'Are you sure?' } 
+      = if can? :manage, :polls
+      	= link_to 'Edit', edit_poll_path(poll) 
+      	= link_to 'Destroy', poll, method: :delete, data: { confirm: 'Are you sure?' } 
 
 = link_to 'New Poll', new_poll_path if can? :manage, :polls

--- a/app/views/polls/show.html.haml
+++ b/app/views/polls/show.html.haml
@@ -3,7 +3,7 @@
 %p
   %b Question:
   = @poll.question
-
-= link_to 'Edit', edit_poll_path(@poll) if can? :manage, :polls
-= '|' if can? :manage, :polls
+= if can? :manage, :polls
+	= link_to 'Edit', edit_poll_path(@poll) 
+	= '|' 
 = link_to 'Back', polls_path 

--- a/app/views/polls/show.html.haml
+++ b/app/views/polls/show.html.haml
@@ -5,5 +5,5 @@
   = @poll.question
 
 = link_to 'Edit', edit_poll_path(@poll) if can? :manage, :polls
-\|
-= link_to 'Back', polls_path if can? :manage, :polls
+= '|' if can? :manage, :polls
+= link_to 'Back', polls_path 

--- a/spec/acceptance/polls_spec.rb
+++ b/spec/acceptance/polls_spec.rb
@@ -18,8 +18,7 @@ feature %q{
 
 
   scenario "create a poll", :js => true do
-    page.find("New Poll", :visible => true).click
-    # page.find("a", :text => "New Poll", :visible => true).click old with "a"
+    visit new_poll_path #check if it is admin problem
     fill_in "poll_question", :with => "Should a bear drink beer or have food with an elephant?"
     page.should have_css("h2", :text => "Please save this poll first to add answers", :visible => true)
     click_button "Save"

--- a/spec/acceptance/polls_spec.rb
+++ b/spec/acceptance/polls_spec.rb
@@ -18,11 +18,11 @@ feature %q{
 
 
   scenario "create a poll", :js => true do
-    visit new_poll_path #check if it is admin problem
+    click_link "New Poll" #check if it is admin problem or visibility
     fill_in "poll_question", :with => "Should a bear drink beer or have food with an elephant?"
     page.should have_css("h2", :text => "Please save this poll first to add answers", :visible => true)
     click_button "Save"
-    page.should have_no_css("h2", :text => "Please save this ppll first to add answers", :visible => true)
+    page.should have_no_css("h2", :text => "Please save this poll first to add answers", :visible => true)
 
     answer_text = "we should ask squirrels"
     fill_in "answer_text", :with => answer_text
@@ -32,7 +32,7 @@ feature %q{
     page.should have_no_css("h5", :text => answer_text, :visible => true)
 
     click_button "Save"
-    page.should have_css("p", :text => "Poll was successfully updated.", :visible => true)
+    page.should have_content("Poll was successfully updated.", :visible => true) #need to see if this ever gets to page
   end
 
 end

--- a/spec/acceptance/polls_spec.rb
+++ b/spec/acceptance/polls_spec.rb
@@ -18,11 +18,12 @@ feature %q{
 
 
   scenario "create a poll", :js => true do
-    page.find("a", :text => 'New Poll', :visible => true).click
+    page.find("New Poll", :visible => true).click
+    # page.find("a", :text => "New Poll", :visible => true).click old with "a"
     fill_in "poll_question", :with => "Should a bear drink beer or have food with an elephant?"
     page.should have_css("h2", :text => "Please save this poll first to add answers", :visible => true)
     click_button "Save"
-    page.should have_no_css("h2", :text => "Please save this pall first to add answers", :visible => true)
+    page.should have_no_css("h2", :text => "Please save this ppll first to add answers", :visible => true)
 
     answer_text = "we should ask squirrels"
     fill_in "answer_text", :with => answer_text


### PR DESCRIPTION
Users previously able to still view "edit" and "destroy" buttons on polls pages. Should disable destroy button, hide all buttons except for show on polls page.
Should get rid of | on specific question page for users, while still separating buttons for admins. 