### PR TITLE
Fix authentication of edit and delete

### DIFF
--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -1,5 +1,6 @@
 class PollsController < ApplicationController
-  load_and_authorize_resource only: [:new, :create, :edit, :update, :destroy, :published] 
+  load_and_authorize_resource only: [:new, :create, :edit, :update, 
+:destroy, :published] 
   before_action :authenticate_user!
 
   # GET /polls
@@ -27,7 +28,6 @@ class PollsController < ApplicationController
   # GET /polls/new
   # GET /polls/new.json
   def new
-
       @poll = Poll.new
       respond_to do |format|
         format.html # new.html.erb

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -1,6 +1,5 @@
 class PollsController < ApplicationController
-  
-  load_and_authorize_resource only: [:new, :create, :edit, :update]
+  load_and_authorize_resource only: [:new, :create, :edit, :update, :destroy, :published] 
   before_action :authenticate_user!
 
   # GET /polls
@@ -28,6 +27,7 @@ class PollsController < ApplicationController
   # GET /polls/new
   # GET /polls/new.json
   def new
+
       @poll = Poll.new
       respond_to do |format|
         format.html # new.html.erb

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -1,6 +1,6 @@
 class PollsController < ApplicationController
   load_and_authorize_resource only: [:new, :create, :edit, :update, 
-:destroy, :published] 
+  :destroy, :published]
   before_action :authenticate_user!
 
   # GET /polls

--- a/app/views/polls/index.html.haml
+++ b/app/views/polls/index.html.haml
@@ -6,8 +6,7 @@
     %h2= poll.question
     .publish
       = if current_user.admin?
-      	=render :partial => "polls/publish_link", :locals => {:poll => poll}
-    .actions
+        =render :partial => "polls/publish_link", :locals => {:poll => poll}.actions
       	= link_to 'Edit', edit_poll_path(poll) 
       	= link_to 'Destroy', poll, method: :delete, data: { confirm: 'Are you sure?' } 
       = link_to 'Show', poll

--- a/app/views/polls/index.html.haml
+++ b/app/views/polls/index.html.haml
@@ -1,12 +1,12 @@
 %h1 Listing polls
 
 
--@polls.each do |poll|
+- @polls.each do |poll|
   .poll{'data-id' => poll.id}
     %h2= poll.question
     .publish
       = if current_user.admin?
-        =render :partial => "polls/publish_link", :locals => {:poll => poll}.actions
+        = render :partial => "polls/publish_link", :locals => {:poll => poll}.actions
       	= link_to 'Edit', edit_poll_path(poll) 
       	= link_to 'Destroy', poll, method: :delete, data: { confirm: 'Are you sure?' } 
       = link_to 'Show', poll

--- a/app/views/polls/index.html.haml
+++ b/app/views/polls/index.html.haml
@@ -5,10 +5,11 @@
   .poll{'data-id' => poll.id}
     %h2= poll.question
     .publish
-      =render :partial => "polls/publish_link", :locals => {:poll => poll}
+      = if current_user.admin?
+      	=render :partial => "polls/publish_link", :locals => {:poll => poll}
     .actions
+      	= link_to 'Edit', edit_poll_path(poll) 
+      	= link_to 'Destroy', poll, method: :delete, data: { confirm: 'Are you sure?' } 
       = link_to 'Show', poll
-      = link_to 'Edit', edit_poll_path(poll) 
-      = link_to 'Destroy', poll, method: :delete, data: { confirm: 'Are you sure?' } 
 
-= link_to 'New Poll', new_poll_path if can? :manage, :polls
+= link_to 'New Poll', new_poll_path if current_user.admin?

--- a/spec/acceptance/polls_spec.rb
+++ b/spec/acceptance/polls_spec.rb
@@ -78,4 +78,3 @@ feature %q{
   end
 
 end
-

--- a/spec/acceptance/polls_spec.rb
+++ b/spec/acceptance/polls_spec.rb
@@ -18,7 +18,7 @@ feature %q{
 
 
   scenario "create a poll", :js => true do
-    page.find("a", :text => 'New Poll', :visible => true).click
+    visit new_poll_path
     fill_in "poll_question", :with => "Should a bear drink beer or have food with an elephant?"
     page.should have_css("h2", :text => "Please save this poll first to add answers", :visible => true)
     click_button "Save"
@@ -78,3 +78,4 @@ feature %q{
   end
 
 end
+

--- a/spec/acceptance/polls_spec.rb
+++ b/spec/acceptance/polls_spec.rb
@@ -19,7 +19,7 @@ feature %q{
 
   scenario "create a poll", :js => true do
     visit new_poll_path
-    fill_in "poll_question", :with => "Should a bear drink beer or have food with an elephant?"
+    fill_in "Question", :with => "Should a bear drink beer or have food with an elephant?"
     page.should have_css("h2", :text => "Please save this poll first to add answers", :visible => true)
     click_button "Save"
     page.should have_no_css("h2", :text => "Please save this pall first to add answers", :visible => true)


### PR DESCRIPTION
After testing previous pull request, some features, such as deleting a poll, were still doable by users. Fixed constraints so that admin status is checked rather than managing polls. This also fixed the rspec admin test, which had been failing previously. 